### PR TITLE
Enhance Netlify CMS and landing templates

### DIFF
--- a/admin/cms.js
+++ b/admin/cms.js
@@ -1,0 +1,2 @@
+CMS.registerPreviewStyle("/css/styles.css");
+CMS.registerPreviewScript("/assets/js/scripts.js");

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -17,6 +17,10 @@ collections:
       - { label: "Hero Title", name: "hero_title", widget: "string" }
       - { label: "Hero Subtitle", name: "hero_subtitle", widget: "string" }
       - { label: "CTA Text", name: "cta_text", widget: "string" }
+      - { label: "Is Copy", name: "is_copy", widget: "boolean", default: false }
+      - label: "Popup HTML"
+        name: "popup_html"
+        widget: "code"
       - label: "Features"
         name: "features"
         widget: "list"
@@ -38,6 +42,18 @@ collections:
         fields:
           - { label: "Question", name: "question", widget: "string" }
           - { label: "Answer", name: "answer", widget: "text" }
+      - label: "Countdown"
+        name: "countdown"
+        widget: "object"
+        fields:
+          - { label: "End Date", name: "end", widget: "datetime", required: false }
+          - { label: "Text Before", name: "pre_text", widget: "string", required: false }
+          - { label: "Text After", name: "post_text", widget: "string", required: false }
+          - label: "Action After"
+            name: "action"
+            widget: "select"
+            required: false
+            options: ["none", "hide", "redirect"]
 
   - name: landing-list
     label: Lista landingów
@@ -58,3 +74,14 @@ collections:
           - label: "HTML вміст"
             name: body
             widget: "text"
+
+  - name: site-settings
+    label: "Site Settings"
+    files:
+      - file: "data/site_settings.yml"
+        label: "General"
+        name: "general"
+        fields:
+          - { label: "Head Code", name: "head_code", widget: "code", required: false }
+          - { label: "Body Code", name: "body_code", widget: "code", required: false }
+          - { label: "Favicon", name: "favicon", widget: "image", required: false }

--- a/admin/index.html
+++ b/admin/index.html
@@ -7,5 +7,6 @@
 </head>
 <body>
   <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+  <script src="/admin/cms.js"></script>
 </body>
 </html>

--- a/data/site_settings.yml
+++ b/data/site_settings.yml
@@ -1,0 +1,3 @@
+head_code: ""
+body_code: ""
+favicon: ""

--- a/layouts/landing.html
+++ b/layouts/landing.html
@@ -4,9 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{ .Title }}</title>
+  {{ with site.Data.site_settings.favicon }}<link rel="icon" href="{{ . }}">{{ end }}
+  {{ with site.Data.site_settings.head_code }}{{ . | safeHTML }}{{ end }}
   <link rel="stylesheet" href="/assets/css/styles.css">
 </head>
 <body>
+  {{ if .Params.is_copy }}
+  <div class="copy-warning" style="background:#ffc;margin:0;padding:10px;text-align:center;">Edytujesz kopię strony</div>
+  {{ end }}
   {{ $base := printf "%s-page/" .Params.template }}
   {{ partial (print $base "hero.html") . }}
   {{ partial (print $base "utp.html") . }}
@@ -15,8 +20,10 @@
   {{ partial (print $base "features.html") . }}
   {{ partial (print $base "offer.html") . }}
   {{ partial (print $base "faq.html") . }}
+  {{ partial (print $base "countdown.html") . }}
   {{ partial (print $base "cta.html") . }}
   {{ partial (print $base "modal.html") . }}
   <script src="/assets/js/scripts.js"></script>
+  {{ with site.Data.site_settings.body_code }}{{ . | safeHTML }}{{ end }}
 </body>
 </html>

--- a/layouts/partials/large-page/countdown.html
+++ b/layouts/partials/large-page/countdown.html
@@ -1,0 +1,35 @@
+{{ if .Params.countdown.end }}
+<section id="countdown-section" class="countdown">
+  <div class="container">
+    {{ with .Params.countdown.pre_text }}<p>{{ . }}</p>{{ end }}
+    <div id="countdown-timer"></div>
+    {{ with .Params.countdown.post_text }}<p>{{ . }}</p>{{ end }}
+  </div>
+</section>
+<script>
+(function(){
+  var end = new Date("{{ .Params.countdown.end }}").getTime();
+  var action = "{{ .Params.countdown.action }}";
+  var timerEl = document.getElementById('countdown-timer');
+  function update(){
+    var now = new Date().getTime();
+    var dist = end - now;
+    if(dist <= 0){
+      clearInterval(intv);
+      if(action === 'hide'){
+        document.getElementById('countdown-section').style.display='none';
+      } else if(action === 'redirect') {
+        window.location.href = '/';
+      }
+      return;
+    }
+    var d = Math.floor(dist/86400000);
+    var h = Math.floor((dist%86400000)/3600000);
+    var m = Math.floor((dist%3600000)/60000);
+    var s = Math.floor((dist%60000)/1000);
+    timerEl.innerHTML = d+"d "+h+"h "+m+"m "+s+"s";
+  }
+  var intv = setInterval(update,1000);update();
+})();
+</script>
+{{ end }}

--- a/layouts/partials/large-page/modal.html
+++ b/layouts/partials/large-page/modal.html
@@ -1,10 +1,12 @@
 <div id="popup" class="popup-overlay">
   <div class="popup-content">
-    <div class="popup-header">
+    <a href="#" class="popup-close">&times;</a>
+    {{ with .Params.popup_html }}
+      {{ . | safeHTML }}
+    {{ else }}
       <h3>🎯 Świetnie!</h3>
-      <a href="#" class="popup-close">&times;</a>
-    </div>
-    <p>Z tego miejsca trafiasz do lejka jednym kliknięciem!</p>
-    <button class="demo-button-inactive" disabled>Demo</button>
+      <p>Z tego miejsca trafiasz do lejka jednym kliknięciem!</p>
+      <button class="demo-button-inactive" disabled>Demo</button>
+    {{ end }}
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add copy flag, popup code and countdown settings to `admin/config.yml`
- add global site settings collection
- inject favicon, head/body code and copy warning in landing template
- make popup content editable
- add optional countdown section
- load CSS/JS for CMS preview

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff410631c8326b508bc8c1bb0db62