### PR TITLE
Add template duplication support

### DIFF
--- a/admin/cms.js
+++ b/admin/cms.js
@@ -1,4 +1,37 @@
 if (window.CMS) {
   CMS.registerPreviewStyle('/css/styles.css');
   CMS.registerPreviewStyle('/js/scripts.js', { raw: false });
+
+  function addDuplicateButton(entry) {
+    const actions = document.querySelector('.nc-entryEditor-actions');
+    if (!actions || actions.querySelector('#duplicate-page')) return;
+    const btn = document.createElement('button');
+    btn.id = 'duplicate-page';
+    btn.type = 'button';
+    btn.innerText = 'Zduplikować';
+    btn.className = 'nc-button';
+    btn.addEventListener('click', async () => {
+      const backend = CMS.getBackend();
+      const collection = entry.get('collection');
+      const slug = entry.get('slug');
+      const data = entry.get('data').set('is_copy', true);
+      const newSlug = `${slug}-copy`;
+      const path = entry.get('path').replace(slug, newSlug);
+      await backend.persistEntry({
+        collection,
+        slug: newSlug,
+        path,
+        data,
+      });
+      window.location.hash = `#/collections/${collection}/entries/${newSlug}`;
+    });
+    actions.appendChild(btn);
+  }
+
+  CMS.registerEventListener({
+    name: 'entry-loaded',
+    handler: ({ entry }) => {
+      setTimeout(() => addDuplicateButton(entry), 500);
+    },
+  });
 }

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -7,26 +7,14 @@ public_folder: "/images"
 
 locales:
   default: pl
-  pl:
-    buttons:
-      create: "Utwórz"
-      delete: "Usuń"
-      edit: "Edytuj"
-      publish: "Opublikuj"
-      save: "Zapisz"
-    collections:
-      landing-pages: "Strony docelowe"
-      landing-list: "Lista landingów"
-      links: "Ustawienia strony"
-    menu:
-      media: "Multimedia"
-      contents: "Treść"
+  pl: /admin/locales/pl.json
 
 collections:
   - name: landing-pages
     label: Strony docelowe
     label_singular: Strona
-    create: true
+    create: false
+    delete: false
     folder: content/landing-pages
     slug: "{{slug}}"
     fields:

--- a/admin/locales/pl.json
+++ b/admin/locales/pl.json
@@ -17,12 +17,16 @@
     },
     "collection": {
       "sidebar": {
-        "collections": "Kolekcje"
+        "collections": "Zbiory",
+        "searchAll": "Szukaj"
       },
       "list": {
         "loadingEntries": "Ładowanie wpisów...",
         "noEntries": "Brak wpisów",
-        "search": "Szukaj"
+        "search": "Szukaj",
+        "sortBy": "Sortuj według",
+        "newEntry": "Nowa strona",
+        "quickAdd": "Szybkie dodanie"
       },
       "collections": {
         "landing-pages": "Strony docelowe",


### PR DESCRIPTION
## Summary
- make landing page templates read-only
- add Polish translations for list buttons
- implement 'Zduplikować' button to clone entries via Netlify CMS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840299a45648326963b5b75ff3c9015